### PR TITLE
Automatically remove the container when it exits

### DIFF
--- a/gracc-apel.service
+++ b/gracc-apel.service
@@ -4,4 +4,4 @@ Description=GRACC APEL reporting Docker container
 
 [Service]
 Type=oneshot
-ExecStart=/bin/docker run -v /etc/grid-security/apel/apelcert.pem:/etc/grid-security/apel/apelcert.pem -v /etc/grid-security/apel/apelkey.pem:/etc/grid-security/apel/apelkey.pem opensciencegrid/gracc-apel --rm
+ExecStart=/bin/docker run --rm -v /etc/grid-security/apel/apelcert.pem:/etc/grid-security/apel/apelcert.pem -v /etc/grid-security/apel/apelkey.pem:/etc/grid-security/apel/apelkey.pem opensciencegrid/gracc-apel

--- a/gracc-apel.service
+++ b/gracc-apel.service
@@ -4,5 +4,4 @@ Description=GRACC APEL reporting Docker container
 
 [Service]
 Type=oneshot
-ExecStart=/bin/docker run -v /etc/grid-security/apel/apelcert.pem:/etc/grid-security/apel/apelcert.pem -v /etc/grid-security/apel/apelkey.pem:/etc/grid-security/apel/apelkey.pem opensciencegrid/gracc-apel
-
+ExecStart=/bin/docker run -v /etc/grid-security/apel/apelcert.pem:/etc/grid-security/apel/apelcert.pem -v /etc/grid-security/apel/apelkey.pem:/etc/grid-security/apel/apelkey.pem opensciencegrid/gracc-apel --rm


### PR DESCRIPTION
added --rm to ExecStart to automatically remove the container when it exits